### PR TITLE
Remove Modification of userAccountControl

### DIFF
--- a/chpass/utils.py
+++ b/chpass/utils.py
@@ -59,13 +59,6 @@ def change_ad_password(user_account, new_password):
     child.send("\n\n")
     child.expect("modifying entry")
 
-    child.sendline("dn: %s" % dn)
-    child.sendline("changetype: modify")
-    child.sendline("replace: userAccountControl")
-    child.sendline("userAccountControl:66048")
-    child.send("\n\n")
-    child.expect("modifying entry")
-
     child.sendeof()
     child.expect(pexpect.EOF)
 


### PR DESCRIPTION
Our modification of userAccountControl re-enabled accounts on Windows, even if the user was sorried.
